### PR TITLE
QoL Improvements

### DIFF
--- a/Scripts/Commander/CommandEntry.cs
+++ b/Scripts/Commander/CommandEntry.cs
@@ -118,9 +118,9 @@ namespace Zat.Commander
             {
 
                 if (!HasGroup) onGroupEmpty?.Invoke();
-                else if (Time.time > nextUpdate) UpdateUI();
+                else if (Time.unscaledTime > nextUpdate) UpdateUI();
 
-                if (Time.time - lastClick >= 0.3f && numClicks > 0 && HasGroup)
+                if (Time.unscaledTime - lastClick >= 0.3f && numClicks > 0 && HasGroup)
                 {
                     if (numClicks == 1) group.Select();
                     if (numClicks == 2) group.MoveCamera();
@@ -182,13 +182,13 @@ namespace Zat.Commander
                 }
             }
 
-            nextUpdate = Time.time + UpdateInterval;
+            nextUpdate = Time.unscaledTime + UpdateInterval;
         }
 
         public void RegisterClick()
         {
             numClicks++;
-            lastClick = Time.time;
+            lastClick = Time.unscaledTime;
         }
     }
 }

--- a/Scripts/Commander/Loader.cs
+++ b/Scripts/Commander/Loader.cs
@@ -50,6 +50,15 @@ namespace Zat.Commander
                 else if (GameState.inst.playingMode.GameUIParent.transform == null) Debugging.Log("Loader", "GameState.inst.playingMode.GameUIParent.transform NULL");
                 return;
             }
+            
+            if (parent.childCount > 0) {
+                Canvas existingCanvas = parent.GetChild(0).GetComponent<Canvas>();
+                if (existingCanvas != null) {
+                    Canvas canvasCanvas = canvas.GetComponent<Canvas>();
+                    canvasCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+                    canvasCanvas.worldCamera = existingCanvas.worldCamera;
+                }
+            }
             canvas.transform.SetParent(parent, true);
             var commander = canvas.AddComponent<CommanderUI>();
             Debugging.Log("Loader", "Initialized Commander");

--- a/Scripts/ModMenu/Loader.cs
+++ b/Scripts/ModMenu/Loader.cs
@@ -6,6 +6,7 @@ using Harmony;
 using I2.Loc;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using Zat.ModMenu.UI;
 using Zat.Shared;
 using Zat.Shared.AssetLoading;
@@ -52,6 +53,7 @@ namespace Zat.ModMenu
             }
             var canvas = GameObject.Instantiate(canvasPrefab) as GameObject;
             //canvas.transform.SetParent(parent, false);
+            canvas.transform.Find("ModSettingsUI").Find("Scroll View").GetComponent<ScrollRect>().scrollSensitivity = 50;
             canvas.AddComponent<ModMenuUI>();
             Debugging.Log("ModMenu", "Running!");
         }


### PR DESCRIPTION
Changed command group canvas from screenspace overlay to screenspace camera.
Changed command entry time from time to unscaledTime.
Changed mod menu scroll rect scroll sensitivity.

Currently the command groups ui will show over the top of all other ui's. This can make it difficult to read and use certain menus, such as the creative menu and the info panel for manor houses that have lots of bonuses. A screenspace overlay canvas will never go behind a screenspace camera canvas, so this had to be changed to resolve the issue.

Hotkey presses were calculated based on the amount of simulated time that had passed. The game changes the simulated timescale based on the speed of the game which meant a double tap was harder to achieve at 3x speed (it gave the user a much smaller window) and a single tap was never resolved when paused. Changing to unscaled time uses the amount of actual time passing without a timescale modifier.

ScrollRect's have a property that controls how fast a scroll on a mouse wheel scrolls. By default it is painstakingly slow, requiring users to click and drag the scroll bar instead. This makes it a much more reasonable speed so mouse wheel scrolling is a feasible alternative.